### PR TITLE
Make vhost work behind Nginx, trust X-Forwarded-For header

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Improves on express.js middleware for vhost by avoiding expensive regex chains.  This will perform better and scale more than connect vhost.
 
-* I started this module while at another company.  It was not being maintained so I forked so it could be improved as necessary *
+If trust proxy is enabled the X-Forwarded-Host header will be respected, so that the hosts can work behind a remote proxy such as Nginx.
 
 
 ``` javascript

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Improves on express.js middleware for vhost by avoiding expensive regex chains.  This will perform better and scale more than connect vhost.
 
-* I started this module while at another company.  It was not being maintained so I forked so it could be improved as necessary *
+If trust proxy is enabled the X-Forwarded-Host header will be respected, so that the hosts can work behind a remote proxy such as Nginx.
 
 
 ``` javascript
@@ -20,7 +20,7 @@ var appFactory = function(echo) {
 };
 
 var server = express();
-server.use(evh.vhost());
+server.use(evh.vhost(server.enabled('trust proxy')));
 server.listen(port);
 
 evh.register('test1-local', appFactory('test1'));

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var appFactory = function(echo) {
 };
 
 var server = express();
-server.use(evh.vhost());
+server.use(evh.vhost(server.enabled('trust proxy')));
 server.listen(port);
 
 evh.register('test1-local', appFactory('test1'));

--- a/lib/vhost.js
+++ b/lib/vhost.js
@@ -2,12 +2,15 @@ var Vhost = function() {
 	this.hostDictionary = {};
 };
 
-Vhost.prototype.vhost = function() {
+Vhost.prototype.vhost = function(trustProxy) {
 	var hostDictionary = this.hostDictionary;
 
 	return function vhost(req, res, next){
 		if (!req.headers.host) return next();
 		var host = req.headers.host.split(':')[0];
+		if (trustProxy && req.headers["x-forwarded-host"]) {
+			var host = req.headers["x-forwarded-host"].split(':')[0];
+		}
 		var server = hostDictionary[host];
 		if (!server){
 			server = hostDictionary['*' + host.substr(host.indexOf('.'))];

--- a/lib/vhost.js
+++ b/lib/vhost.js
@@ -2,12 +2,15 @@ var Vhost = function() {
 	this.hostDictionary = {};
 };
 
-Vhost.prototype.vhost = function() {
+Vhost.prototype.vhost = function(trustProxy) {
 	var hostDictionary = this.hostDictionary;
 
 	return function vhost(req, res, next){
 		if (!req.headers.host) return next();
 		var host = req.headers.host.split(':')[0];
+		if (trustProxy && req.headers["x-forwarded-host"]) {
+			host = req.headers["x-forwarded-host"].split(':')[0];
+		}
 		var server = hostDictionary[host];
 		if (!server){
 			server = hostDictionary['*' + host.substr(host.indexOf('.'))];

--- a/lib/vhost.js
+++ b/lib/vhost.js
@@ -9,7 +9,7 @@ Vhost.prototype.vhost = function(trustProxy) {
 		if (!req.headers.host) return next();
 		var host = req.headers.host.split(':')[0];
 		if (trustProxy && req.headers["x-forwarded-host"]) {
-			var host = req.headers["x-forwarded-host"].split(':')[0];
+			host = req.headers["x-forwarded-host"].split(':')[0];
 		}
 		var server = hostDictionary[host];
 		if (!server){


### PR DESCRIPTION
This makes vhost work when the host(s) are behind Nginx. 
In Nginx you'd set something like.

```
        location / {
                proxy_set_header X-Forwarded-Host $host;
                proxy_set_header X-Forwarded-Server $host;
                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                proxy_pass http://127.0.0.1:3000/;
        }
```

Without this the host is not known so the vhost mapping won't work.
